### PR TITLE
typo fix for license and added readme = "README.md" to avoid pypi release error about wrong `long description`

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -3,7 +3,7 @@ name = "{{cookiecutter.__project_slug}}"
 version = "0.1.0"
 description = "Enter description of your project here"
 authors = ["{{cookiecutter.__author}}"]
-license = "{{cookiecutter.__author}}"
+license = "{{cookiecutter.license}}"
 include = ["README.md", "src/{{cookiecutter.__project_slug}}/schema", "project"]
 
 [tool.poetry.dependencies]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Enter description of your project here"
 authors = ["{{cookiecutter.__author}}"]
 license = "{{cookiecutter.license}}"
+readme = "README.md"
 include = ["README.md", "src/{{cookiecutter.__project_slug}}/schema", "project"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
 - `license = "{{cookiecutter.license}}" `
 - `readme = "README.md"` avoids `long description` error  during pypi release