### PR TITLE
Placeholder updates and bug fixes

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,5 +18,5 @@
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
     "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace(' ', '_')|replace('-', '_') }}",
-    "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
+    "github_token_for_pypi_deployment": "PYPI_PASSWORD"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,7 +13,7 @@
     "create_python_classes": ["Yes", "No"],
     "use_schemasheets": [
         "Yes",
-        "No (next two questions are ignored)"
+        "No"
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -8,15 +8,10 @@ from pathlib import Path
 shutil.rmtree("licenses")
 
 project_slug = '{{ cookiecutter.__project_slug}}'
-create_python_classes = '{{ cookiecutter.create_python_classes}}'
-use_schemasheets_option = '{{ cookiecutter.use_schemasheets }}'
+create_python_classes = '{{ cookiecutter.create_python_classes }}'
 
 if create_python_classes == "No":
     print("TODO - cleanup python")
-
-if use_schemasheets_option == "No":
-    print("TODO - Change MakeFile: remove compile-sheets from gen-project")
-
 
 print("** PROJECT CREATION COMPLETE **\n")
 print("Next steps:")

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -9,9 +9,14 @@ shutil.rmtree("licenses")
 
 project_slug = '{{ cookiecutter.__project_slug}}'
 create_python_classes = '{{ cookiecutter.create_python_classes}}'
+use_schemasheets_option = '{{ cookiecutter.use_schemasheets }}'
 
 if create_python_classes == "No":
     print("TODO - cleanup python")
+
+if use_schemasheets_option == "No":
+    print("TODO - Change MakeFile: remove compile-sheets from gen-project")
+
 
 print("** PROJECT CREATION COMPLETE **\n")
 print("Next steps:")

--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
@@ -25,6 +25,7 @@ jobs:
     
     - name: Build documentation.
       run: |
+        mkdir -p docs
         touch docs/.nojekyll
         poetry run gen-doc -d docs src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml
         poetry run mkdocs gh-deploy

--- a/{{cookiecutter.project_name}}/.github/workflows/pypi-publish.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pypi-publish.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2.2.2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install Poetry
       uses: snok/install-poetry@v1.1.6

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -80,7 +80,7 @@ site: gen-project gendoc
 deploy: all mkd-gh-deploy
 
 compile-sheets:
-{% if {{ cookiecutter.use_schemasheets }} %}
+{% if cookiecutter.use_schemasheets == "Yes"  %}
 	$(RUN) sheets2linkml --gsheet-id $(SHEET_ID) $(SHEET_TABS) > $(SHEET_MODULE_PATH).tmp && mv $(SHEET_MODULE_PATH).tmp $(SHEET_MODULE_PATH)
 {% endif %}
 

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -80,7 +80,7 @@ site: gen-project gendoc
 deploy: all mkd-gh-deploy
 
 compile-sheets:
-{% if cookiecutter.use_schemasheets %}
+{% if {{ cookiecutter.use_schemasheets }} %}
 	$(RUN) sheets2linkml --gsheet-id $(SHEET_ID) $(SHEET_TABS) > $(SHEET_MODULE_PATH).tmp && mv $(SHEET_MODULE_PATH).tmp $(SHEET_MODULE_PATH)
 {% endif %}
 
@@ -89,14 +89,8 @@ gen-examples:
 	cp src/data/examples/* $(EXAMPLEDIR)
 
 # generates all project files
-{% if {{ cookiecutter.use_schemasheets }} == "Yes" %}
-    gen-project: $(PYMODEL) compile-sheets
-		$(RUN) gen-project -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
-{% else %}
-	gen-project: $(PYMODEL)
-		$(RUN) gen-project -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
-{% endif %}
-
+gen-project: $(PYMODEL) compile-sheets
+	$(RUN) gen-project -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
 
 test: test-schema test-python
 test-schema:

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -89,8 +89,14 @@ gen-examples:
 	cp src/data/examples/* $(EXAMPLEDIR)
 
 # generates all project files
-gen-project: $(PYMODEL) compile-sheets
-	$(RUN) gen-project -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
+{% if {{ cookiecutter.use_schemasheets }} == "Yes" %}
+    gen-project: $(PYMODEL) compile-sheets
+		$(RUN) gen-project -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
+{% else %}
+	gen-project: $(PYMODEL)
+		$(RUN) gen-project -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
+{% endif %}
+
 
 test: test-schema test-python
 test-schema:

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -20,3 +20,6 @@ schemasheets = "^0.1.14"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.extras]
+docs = ["linkml", "mkdocs-material"]

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "{{cookiecutter.__project_slug}}"
 version = "0.1.0"
-description = "Enter description of your project here"
+description = "{{cookiecutter.description}}"
 authors = ["{{cookiecutter.__author}}"]
 license = "{{cookiecutter.license}}"
 readme = "README.md"

--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml
@@ -32,8 +32,7 @@ classes:
       - id
       - name
       - description
-    class_uri:
-     - schema:Thing
+    class_uri: schema:Thing
 
   {{cookiecutter.main_schema_class}}:
     is_a: NamedThing

--- a/{{cookiecutter.project_name}}/tests/test_data.py
+++ b/{{cookiecutter.project_name}}/tests/test_data.py
@@ -4,7 +4,7 @@ import glob
 import unittest
 
 from linkml_runtime.loaders import yaml_loader
-from my_awesome_schema.datamodel import {{cookiecutter.main_schema_class}}
+from {{cookiecutter.__project_slug}}.datamodel import {{cookiecutter.main_schema_class}}
 
 ROOT = os.path.join(os.path.dirname(__file__), '..')
 DATA_DIR = os.path.join(ROOT, "src", "data", "examples")


### PR DESCRIPTION
 - ~my_awesome_schema~ => `{{cookiecutter.__project_slug}}`
 - Added docs extras in the toml file use by doc deploy workflow.
 - Added placeholder for description in toml file -> "github_token_for_pypi_deployment": "PYPI_PASSWORD ~(leave blank if not a python project)~"
 - `class_uri: schema:Thing` converted from a `list` to a scalar entity
 - `{% if cookiecutter.use_schemasheets == "Yes" %}` =="Yes" was missing