### PR TITLE
bare cruft installs click at > 8.0.4, then syntax errors on cruft create b/c of 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ A [Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/) template for pr
 
 ## Standard Protocol
 
-### Step 1: Install cruft and poetry
+### Step 1: Create a virtual environment
+
+1: Create a Python virtual environment. You can read [this 
+guide](https://realpython.com/python-virtual-environments-a-primer/) to learn more about them and how to create one.
+
+After creating a virtual environment, it's as simple as:
 
 1a: [install poetry](https://python-poetry.org/docs/):
 
@@ -13,8 +18,8 @@ A [Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/) template for pr
 
 1b: [install cruft](https://cruft.github.io/cruft/):
 
-`pip3 install click==8.0.4`
 `pip3 install cruft`
+
 
 ### Use cruft to generate a new project:
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A [Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/) template for pr
 
 1b: [install cruft](https://cruft.github.io/cruft/):
 
+`pip3 install click==8.0.4`
 `pip3 install cruft`
 
 ### Use cruft to generate a new project:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,5 +17,6 @@
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
+    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower }}",
     "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower()|replace(' ', '_')|replace('-', '_')  }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower()|replace(' ', '_')|replace('-', '_') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",
@@ -17,6 +17,6 @@
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
-    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace(' ', '_')|replace('-', '_')  }}",
+    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace(' ', '_')|replace('-', '_') }}",
     "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower()|replace(' ', '_')|replace('-', '_') }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '_')|replace('-', '_') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower()|replace('-', '_') }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower() }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",
@@ -17,6 +17,6 @@
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
-    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace('-', '_') }}",
+    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace('-', '_')|replace(' ','_' }}",
     "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower() }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower()|replace('-', '_') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower() }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower()|replace('-', '_') }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower()|replace(' ', '_')|replace('-', '_')  }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower()|replace(' ', '-') }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower() }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",
@@ -17,6 +17,6 @@
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
-    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace(' ', '-') }}",
+    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower() }}",
     "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
-    "project_name": "my awesome schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower()|replace(' ', '-') }}",
+    "project_name": "my-awesome-schema",
+    "__project_slug": "{{ cookiecutter.project_name|lower()|replace('-', '_') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,6 +17,6 @@
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
-    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower() }}",
+    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace('-', '_') }}",
     "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '_')|replace('-', '_') }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",
@@ -17,6 +17,5 @@
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
-    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower|replace(' ', '_')|replace('-', '_') }}",
     "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '_')|replace('-', '_') }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', 'test')|replace('-', '_') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "my-awesome-schema",
+    "project_name": "my awesome schema",
     "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', 'test')|replace('-', '_') }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '_')|replace('-', '_') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",
@@ -17,6 +17,6 @@
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
-    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace(' ', '_')|replace('-', '_') }}",
+    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower|replace(' ', '_')|replace('-', '_') }}",
     "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,6 +17,6 @@
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
-    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace('-', '_')|replace(' ','_' }}",
+    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace(' ', '_')|replace('-', '_')  }}",
     "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my-awesome-schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower()|replace(' ', '-') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",
@@ -17,6 +17,6 @@
     ],
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
-    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower }}",
+    "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace(' ', '-') }}",
     "github_token_for_pypi_deployment": "PYPI_PASSWORD (leave blank if not a python project)"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "my awesome schema",
-    "__project_slug": "{{ cookiecutter.project_name|lower|replace(' ', '-') }}",
+    "__project_slug": "{{ cookiecutter.project_name|lower()|replace(' ', '-') }}",
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",


### PR DESCRIPTION
```
"__project_slug": "{{ cookiecutter.project_name|lower()|replace(' ', '_')|replace('-', '_') }}",
```
generates an error in `cruft create` if the version of click installed > 8.0.4.  (I am trying a bare install of cruft in prep for linkml tutorial, as a test of the recipe). 

I am not quite sure how to make this a requirement.  For now I just added it to the README we want to go back to a slightly less helpful rewrite rule here and just fail the project creation if the naming convention is not quite right?  

Another option is to have the user wrap the project creation in a virtual environment via instructions in the README.  