### PR TITLE
Remove google_analytics_gtag field

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,11 +4,10 @@
     "github_org": "my-org",
     "__source_path": "src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml",
     "project_description": "This is the project description.",
-      "full_name": "My Name",
-      "email": "my-name@my-org.org",
+    "full_name": "My Name",
+    "email": "my-name@my-org.org",
     "__author": "{{cookiecutter.full_name}} <{{cookiecutter.email}}>",
     "license": ["MIT", "BSD-3", "GNU GPL v3.0", "Apache Software License 2.0"],
-    "google_analytics_gtag": "G-2SYBSJVZ23",
     "main_schema_class": "Person",
     "create_python_classes": ["Yes", "No"],
     "use_schemasheets": [

--- a/{{cookiecutter.project_name}}/mkdocs.yml
+++ b/{{cookiecutter.project_name}}/mkdocs.yml
@@ -1,8 +1,6 @@
 site_name: "{{cookiecutter.project_name}}"
 theme:
   name: material
-  analytics:
-    gtag: {{cookiecutter.google_analytics_gtag}}
 #  palette:
 #    scheme: slate
 #    primary: cyan
@@ -17,3 +15,10 @@ nav:
   - About: about.md
 site_url: https://{{cookiecutter.github_org}}.github.io/{{cookiecutter.project_name}}
 repo_url: https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.project_name}}
+
+# Uncomment this block to enable use of Google Analytics. 
+# Replace the property value with your own ID.
+# extra:
+#   analytics:
+#     provider: google
+#     property: G-XXXXXXXXXX


### PR DESCRIPTION
Remove `google_analytics_gtag` from cookiecutter prompts and `mkdocs.yaml`. Replace it with a commented-out block to help users get started if they want to opt-in to Google Analytics.

Fixes #23 