### PR TITLE
fix(setup): fixes for make setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,17 @@ See [linkml/linkml-project-cookiecutter](https://github.com/linkml/linkml-projec
 Change to the folder your generated project is in
 
 ```bash
-cd linkml-projects/my-awesome-schema  # using the folder example above
+cd my-awesome-schema  # using the folder example above
+```
+
+Connect project to Git
+```bash
+git init
+git remote add origin https://github.com/my-org/my-awesome-schema.git
+```
+
+Setup the LinkML project
+```bash
 make setup
 ```
 

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -8,8 +8,8 @@ SHELL := bash
 
 RUN = poetry run
 # get values from about.yaml file
-SCHEMA_NAME = $(shell sh ./utils/get-value.sh name)
-SOURCE_SCHEMA_PATH = $(shell sh ./utils/get-value.sh source_schema_path)
+SCHEMA_NAME = $(shell ${SHELL} ./utils/get-value.sh name)
+SOURCE_SCHEMA_PATH = $(shell ${SHELL} ./utils/get-value.sh source_schema_path)
 SOURCE_SCHEMA_DIR = $(dir $(SOURCE_SCHEMA_PATH))
 SRC = src
 DEST = project
@@ -17,8 +17,8 @@ PYMODEL = $(SRC)/$(SCHEMA_NAME)/datamodel
 DOCDIR = docs
 EXAMPLEDIR = examples
 SHEET_MODULE = {{cookiecutter.__google_sheet_module}}
-SHEET_ID = $(shell sh ./utils/get-value.sh google_sheet_id)
-SHEET_TABS = $(shell sh ./utils/get-value.sh google_sheet_tabs)
+SHEET_ID = $(shell ${SHELL} ./utils/get-value.sh google_sheet_id)
+SHEET_TABS = $(shell ${SHELL} ./utils/get-value.sh google_sheet_tabs)
 SHEET_MODULE_PATH = $(SOURCE_SCHEMA_DIR)/$(SHEET_MODULE).yaml
 
 # basename of a YAML file in model/
@@ -97,19 +97,19 @@ gen-project: $(PYMODEL)
 
 test: test-schema test-python
 test-schema:
-	$(RUN) gen-project -d tmp $(SOURCE_SCHEMA_PATH) 
+	$(RUN) gen-project -d tmp $(SOURCE_SCHEMA_PATH)
 
 test-python:
 	$(RUN) python -m unittest discover
 
 lint:
-	$(RUN) linkml-lint $(SOURCE_SCHEMA_PATH) 
+	$(RUN) linkml-lint $(SOURCE_SCHEMA_PATH)
 
 check-config:
 	@(grep my-datamodel about.yaml > /dev/null && printf "\n**Project not configured**:\n\n  - Remember to edit 'about.yaml'\n\n" || exit 0)
 
 convert-examples-to-%:
-	$(patsubst %, $(RUN) linkml-convert  % -s $(SOURCE_SCHEMA_PATH) -C Person, $(shell find src/data/examples -name "*.yaml")) 
+	$(patsubst %, $(RUN) linkml-convert  % -s $(SOURCE_SCHEMA_PATH) -C Person, $(shell find src/data/examples -name "*.yaml"))
 
 examples/%.yaml: src/data/examples/%.yaml
 	$(RUN) linkml-convert -s $(SOURCE_SCHEMA_PATH) -C Person $< -o $@


### PR DESCRIPTION
This PR seems to fix the following issues with `make setup` procedure:

1. Makefile bad substitution (and remove some trailing white spaces)
2. https://github.com/linkml/linkml-project-cookiecutter/issues/33
```
(baselink-py3.10) ~/git/hub/projects/baselink/baselink$ make setup
./utils/get-value.sh: 4: Bad substitution
./utils/get-value.sh: 4: Bad substitution
poetry install

This does not appear to be a Git project
```