### PR TITLE
fix(readme): add missing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Actions that autogenerate this documentation on release of your schema repositor
 https://my-user-or-organization.github.io/my-awesome-schema/ 
 
 ```bash
+pip install mkdocs-material mkdocs-mermaid2-plugin
 make serve
 ```
 


### PR DESCRIPTION
This PR adds two missing packages needed by `make serve` command in step 7

```
$ make serve
poetry run mkdocs serve
ERROR    -  Config value 'theme': Unrecognised theme name: 'material'. The available installed themes are: mkdocs, readthedocs
ERROR    -  Config value 'plugins': The "mermaid2" plugin is not installed
Aborted with 2 Configuration Errors!
make: *** [Makefile:137: mkd-serve] Error 1
```