### PR TITLE
fix(poetry): workaround 'not a git project'

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -48,7 +48,9 @@ setup: install gen-project gen-examples gendoc git-init-add
 
 # install any dependencies required for building
 install:
+	git init     # issues/33
 	poetry install
+	rm -fr .git  # issues/33
 .PHONY: install
 
 # ---


### PR DESCRIPTION
This PR allows users to bypass https://github.com/linkml/linkml-project-cookiecutter/issues/33 but is not full fix 

(i.e. git repo creation is done in step 8 but is required for step 4, so possible design fault).