### PR TITLE
fix(makefile): keep git repo, needed in step 8

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -50,7 +50,6 @@ setup: install gen-project gen-examples gendoc git-init-add
 install:
 	git init     # issues/33
 	poetry install
-	rm -fr .git  # issues/33
 .PHONY: install
 
 # ---


### PR DESCRIPTION
This PR is followup to #38 and fully fixes #33.

We should not remove .git/ because step 8 in README requires git repository.