### PR TITLE
chore: bump package versions

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -9,7 +9,7 @@ include = ["README.md", "src/{{cookiecutter.__project_slug}}/schema", "project"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-linkml-runtime = "^1.1.24"
+linkml-runtime = "^1.4"
 
 [tool.poetry-dynamic-versioning]
 enable = true
@@ -17,13 +17,14 @@ vcs = "git"
 style = "pep440"
 
 [tool.poetry.dev-dependencies]
-linkml = "^1.3.5"
-mkdocs-material = "^8.2.8"
-mkdocs-mermaid2-plugin = "^0.6.0"
-schemasheets = "^0.1.14"
+cruft = "^2.12"
+linkml = "^1.4"
+mkdocs-material = "^9.0"
+mkdocs-mermaid2-plugin = "^0.6"
+schemasheets = "^0.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+requires = ["poetry-core>=1.5.0", "poetry-dynamic-versioning"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.extras]


### PR DESCRIPTION
This PR bumps package versions to latest available but allows update to later version per https://python-poetry.org/docs/dependency-specification/#caret-requirements

Related  issue: https://github.com/linkml/linkml/issues/1282