### PR TITLE
fix: remove .git/ on make clean

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -161,5 +161,6 @@ git-status:
 clean:
 	rm -rf $(DEST)
 	rm -rf tmp
+	rm -fr .git/
 
 include project.Makefile


### PR DESCRIPTION
This PR cleans git repository when `make clean` is executed.

Otherwise our git history keeps growing every time we repeat  `make clean && make setup`.

Maybe we are troubleshooting or forgot to edit our schema - so fresh git is best.