### PR TITLE
docs: remove superfluous poetry step

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ curl -sSL https://install.python-poetry.org | python3 -
 mkdir linkml-projects
 cd linkml-projects
 poetry init # creates a new poetry project with pyproject.toml.  Note this is not a new linkml project, it is just a virtual environment to install cruft.
-poetry add click==8.0.4
-poetry install # this creates your virtual environment.
+poetry add click==8.0.4  # this creates your virtual environment.
 ```
 
 Add `poetry-dynamic-versioning` as a plugin


### PR DESCRIPTION
This PR removes unnecessary `poetry install` step because it does nothing.

```]
$ poetry install
Installing dependencies from lock file

No dependencies to install or update

/home/noel/git/hub/lmodel/uco/uco-identity/uco_identity does not contain any element
```

Closes https://github.com/linkml/linkml-project-cookiecutter/issues/37