### PR TITLE
feat: add environment variable for gen-owl & document 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ See [linkml/linkml-project-cookiecutter](https://github.com/linkml/linkml-projec
 
 ### Step 4: Setup the LinkML project
 
-Optionally set project generation environment variables (see `gen-doc --help` and `gen-project --help`):
+Optionally set project generation environment variables for gen-project, gen-doc, gen-owl (see --help for supported OPTIONS). Supported environment variables are listed here:
 
 ```
 export LINKML_COOKIECUTTER_GEN_DOC_ARGS=--no-mergeimports      # example
 export LINKML_COOKIECUTTER_GEN_PROJECT_ARGS=--no-mergeimports  # example
+export LINKML_COOKIECUTTER_GEN_OWL_ARGS='--no-type-objects --no-metaclasses'  # example
 ```
 
 Change to the folder your generated project is in

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -32,6 +32,11 @@ ifdef LINKML_COOKIECUTTER_GEN_DOC_ARGS
 GEN_DARGS = ${LINKML_COOKIECUTTER_GEN_DOC_ARGS}
 endif
 
+GEN_OARGS =
+ifdef LINKML_COOKIECUTTER_GEN_OWL_ARGS
+GEN_OARGS = ${LINKML_COOKIECUTTER_GEN_OWL_ARGS}
+endif
+
 
 # basename of a YAML file in model/
 .PHONY: all clean
@@ -107,6 +112,14 @@ gen-project: $(PYMODEL) compile-sheets
 gen-project: $(PYMODEL)
 	$(RUN) gen-project ${GEN_PARGS} -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
 {% endif %}
+
+# regenerate specific project file if custom args are defined
+
+## owl
+ifneq ($(strip ${GEN_OARGS}),)
+	$(RUN) gen-owl ${GEN_OARGS} -o $(DEST)/owl/{{cookiecutter.__project_slug}}.owl.ttl $(SOURCE_SCHEMA_PATH)
+endif
+
 
 test: test-schema test-python
 test-schema:


### PR DESCRIPTION
This PR adds feature to run `gen-owl` with non-default OWL classes and properties. 

See https://github.com/linkml/linkml-project-cookiecutter/issues/51 for discussion.

See https://github.com/linkml/linkml/issues/510#issuecomment-991420907 for use case.

Changes:
- introduce `LINKML_COOKIECUTTER_GEN_OWL_ARGS` environment variable support
- updated README to document this


