### PR TITLE
Use Makefile targets for documentation deployment

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
@@ -28,5 +28,5 @@ jobs:
         run: |
           mkdir -p docs
           touch docs/.nojekyll
-          poetry run gen-doc -d docs src/{{cookiecutter.__project_slug}}/schema/{{cookiecutter.__project_slug}}.yaml
-          poetry run mkdocs gh-deploy
+          make gendoc
+          make mkd-gh-deploy


### PR DESCRIPTION
Use available Makefile rules in documentation deployment workflow rather than manually writing the commands.