### PR TITLE
fix(github): ensure about.md is handled

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
@@ -29,4 +29,7 @@ jobs:
           mkdir -p docs
           touch docs/.nojekyll
           make gendoc
+          ([ ! -f docs/about.md ] && cp src/docs/about.md docs/) || true
           make mkd-gh-deploy
+
+...


### PR DESCRIPTION
This PR ensures an "about.md" exists in generated website (avoids 404 not found).