### PR TITLE
Codespell: config, workflow + typos fixed

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+#
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ make test
 
 ### Step 7: Auto-generate your documentation locally
 
-LinkML generates schema documenation automatically. Step 7 here, allows you to
+LinkML generates schema documentation automatically. Step 7 here, allows you to
 preview the documentation that LinkML generates before pushing to GitHub.
 Note, this template comes with GitHub Actions that autogenerate this
 documentation on release of your schema repository at a URL like this one:

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -46,7 +46,7 @@ help: status
 	@echo "make site -- makes site locally"
 	@echo "make install -- install dependencies"
 	@echo "make test -- runs tests"
-	@echo "make lint -- perfom linting"
+	@echo "make lint -- perform linting"
 	@echo "make testdoc -- builds docs and runs local test server"
 	@echo "make deploy -- deploys site"
 	@echo "make update -- updates linkml version"
@@ -67,7 +67,7 @@ install:
 .PHONY: install
 
 # ---
-# Project Syncronization
+# Project Synchronization
 # ---
 #
 # check we are up to date

--- a/{{cookiecutter.project_name}}/project/jsonld/{{cookiecutter.__project_slug}}.jsonld
+++ b/{{cookiecutter.project_name}}/project/jsonld/{{cookiecutter.__project_slug}}.jsonld
@@ -191,7 +191,7 @@
       "definition_uri": "https://w3id.org/linkml/Objectidentifier",
       "description": "A URI or CURIE that represents an object in the model.",
       "comments": [
-        "Used for inheritence and type checking"
+        "Used for inheritance and type checking"
       ],
       "from_schema": "https://w3id.org/linkml/types",
       "imported_from": "linkml:types",


### PR DESCRIPTION
But may be since a template I should just leave it to "typos fixed"?