### PR TITLE
Pin rdflib to version 6 to fix #73

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -10,6 +10,7 @@ include = ["README.md", "src/{{cookiecutter.__project_slug}}/schema", "project"]
 [tool.poetry.dependencies]
 python = "^3.9"
 linkml-runtime = "^1.1.24"
+rdflib = "^6"  # Version 7 breaks compatibility: https://github.com/linkml/linkml/issues/1567
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
RDFLib version 7 changes the API in ways which break with aspects of LinkML runtime. For now, pin RDFLib to version 6.

See also:
    https://github.com/linkml/linkml/issues/1567