### PR TITLE
Switch actions to pipx-installing poetry

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
@@ -13,13 +13,13 @@ jobs:
         with:
           fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
 
-      - name: Set up Python 3.
+      - name: Set up Python.
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
       - name: Install Poetry.
-        uses: snok/install-poetry@v1.3
+        run: pipx install poetry
 
       - name: Install dependencies.
         run: poetry install -E docs
@@ -31,5 +31,3 @@ jobs:
           make gendoc
           ([ ! -f docs/about.md ] && cp src/docs/about.md docs/) || true
           make mkd-gh-deploy
-
-...

--- a/{{cookiecutter.project_name}}/.github/workflows/main.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/main.yaml
@@ -1,6 +1,5 @@
 # Built from:
 # https://docs.github.com/en/actions/guides/building-and-testing-python
-# https://github.com/snok/install-poetry#workflows-and-tips
 ---
 name: Build and test {{cookiecutter.__project_slug}}
 
@@ -19,13 +18,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ "{{" }} matrix.python-version {{ "}}" }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ "{{" }} matrix.python-version {{ "}}" }}
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3
+        run: pipx install poetry
 
       - name: Install dependencies
         run: poetry install --no-interaction --no-root

--- a/{{cookiecutter.project_name}}/.github/workflows/pypi-publish.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/pypi-publish.yaml
@@ -20,12 +20,8 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pip install poetry
+          pipx install poetry
           poetry self add "poetry-dynamic-versioning[plugin]"
-        # uses: snok/install-poetry@v1.1.6
-        # with:
-        #   virtualenvs-create: true
-        #   virtualenvs-in-project: true
 
       # - name: Install dependencies
       #   run: poetry install --no-interaction


### PR DESCRIPTION
No need to use a special action for setting up poetry. `pipx` is available by default and can be used to install poetry. 

Installing poetry this way also has the advantage that is is in its own isolated environment.