### PR TITLE
Describe how to deploy docs to gh-apges & limit required permissions for build-doc action

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ See [How to register a schema](https://linkml.io/linkml/faq/contributing.html#ho
 
 ### Making releases
 
-See [How to Manage Releases of your LinkML Schema](https://linkml.io/linkml/howtos/managing-releases.html)
+See [How to Manage Releases of your LinkML Schema](https://linkml.io/linkml/howtos/manage-releases.html)
 
 ## Keeping your project up to date
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,20 @@ make serve
    git push -u origin main
    ```
 
+3. Configure your repository for deploying the documentation as GitHub pages
+
+* Under Settings > Actions > General in section "Workflow Permissions" mark "Read repository and packages permission".
+* Under Pages in section "Build and Deployment":
+  * Under "Source" select "Deploy from a branch"
+  * Under "Branch" select "gh-pages" and "/ (root)"
+
 ### Step 7: Register the schema
 
 See [How to register a schema](https://linkml.io/linkml/faq/contributing.html#how-do-i-register-my-schema)
+
+### Making releases
+
+See [How to Manage Releases of your LinkML Schema](https://linkml.io/linkml/howtos/managing-releases.html)
 
 ## Keeping your project up to date
 

--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
@@ -7,6 +7,13 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      contents: write  # to let mkdocs write the new docs
+      pages: write     # to deploy to Pages
+      id-token: write  # to verify the deployment originates from an appropriate source
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,5 +38,3 @@ jobs:
           make gendoc
           ([ ! -f docs/about.md ] && cp src/docs/about.md docs/) || true
           make mkd-gh-deploy
-
-...


### PR DESCRIPTION
Describe how to configure the GitHub project. The PR also changes the action to no longer require write access on project level. Instead it only sets the minimal required permissions. It gives write permission only to the job that needs it (pages deployment).

I also added a link to the new ~~unreleased~~ section on "manage releases" in the linkML how-tos (https://github.com/linkml/linkml/pull/1765).

Closes #61