### PR TITLE
Ensure that gendoc copies all custom docs

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -157,7 +157,7 @@ $(DOCDIR):
 	mkdir -p $@
 
 gendoc: $(DOCDIR)
-	cp $(SRC)/docs/*md $(DOCDIR) ; \
+	cp -rf $(SRC)/docs/* $(DOCDIR) ; \
 	$(RUN) gen-doc ${GEN_DARGS} -d $(DOCDIR) $(SOURCE_SCHEMA_PATH)
 
 testdoc: gendoc serve


### PR DESCRIPTION
Ensure that gendoc copies all custom docs, including subdirs and other datatypes. Both are important as we, for example, want to be able to link images as well as other data in our docs.