### PR TITLE
chore: 1st change make setup commit msg

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -173,7 +173,7 @@ git-init:
 git-add: .cruft.json
 	git add .
 git-commit:
-	git commit -m 'chore: initial commit' -a
+	git commit -m 'chore: make setup was run' -a
 git-status:
 	git status
 


### PR DESCRIPTION
This PR updates Makefile to avoid multiple commit messages saying "initial commit" as user may run `make setup` multiple times => commit history looks funny with multiple "initial commits".