### PR TITLE
feat: 3rd use environment vars to workaround issues

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -6,6 +6,14 @@ SHELL := bash
 .SUFFIXES:
 .SECONDARY:
 
+# environment variables
+.EXPORT_ALL_VARIABLES:
+ifdef LINKML_ENVIRONMENT_FILENAME
+include ${LINKML_ENVIRONMENT_FILENAME}
+else
+include config.env
+endif
+
 RUN = poetry run
 # get values from about.yaml file
 SCHEMA_NAME = $(shell ${SHELL} ./utils/get-value.sh name)
@@ -21,17 +29,29 @@ SHEET_ID = $(shell ${SHELL} ./utils/get-value.sh google_sheet_id)
 SHEET_TABS = $(shell ${SHELL} ./utils/get-value.sh google_sheet_tabs)
 SHEET_MODULE_PATH = $(SOURCE_SCHEMA_DIR)/$(SHEET_MODULE).yaml
 
-# environment variables
-include config.env
-
-GEN_PARGS =
-ifdef LINKML_GENERATORS_PROJECT_ARGS
-GEN_PARGS = ${LINKML_GENERATORS_PROJECT_ARGS}
+CONFIG_YAML =
+ifdef LINKML_GENERATORS_CONFIG_YAML
+CONFIG_YAML = ${LINKML_GENERATORS_CONFIG_YAML}
 endif
 
-GEN_DARGS =
-ifdef LINKML_GENERATORS_MARKDOWN_ARGS
-GEN_DARGS = ${LINKML_GENERATORS_MARKDOWN_ARGS}
+GEN_DOC_ARGS =
+ifdef LINKML_GENERATORS_DOC_ARGS
+GEN_DOC_ARGS = ${LINKML_GENERATORS_DOC_ARGS}
+endif
+
+GEN_OWL_ARGS =
+ifdef LINKML_GENERATORS_OWL_ARGS
+GEN_OWL_ARGS = ${LINKML_GENERATORS_OWL_ARGS}
+endif
+
+GEN_JAVA_ARGS =
+ifdef LINKML_GENERATORS_JAVA_ARGS
+GEN_JAVA_ARGS = ${LINKML_GENERATORS_JAVA_ARGS}
+endif
+
+GEN_TS_ARGS =
+ifdef LINKML_GENERATORS_TYPESCRIPT_ARGS
+GEN_TS_ARGS = ${LINKML_GENERATORS_TYPESCRIPT_ARGS}
 endif
 
 
@@ -103,16 +123,29 @@ gen-examples:
 # generates all project files
 {% if cookiecutter.use_schemasheets == "Yes"  %}
 gen-project: $(PYMODEL) compile-sheets
-	$(RUN) gen-project ${GEN_PARGS} -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
+	$(RUN) gen-project ${CONFIG_YAML} -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
 {% else %}
 gen-project: $(PYMODEL)
-	$(RUN) gen-project ${GEN_PARGS} -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
+	$(RUN) gen-project ${CONFIG_YAML} -d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
 {% endif %}
+
+# non-empty arg triggers owl (workaround https://github.com/linkml/linkml/issues/1453)
+ifneq ($(strip ${GEN_OWL_ARGS}),)
+       $(RUN) gen-owl ${GEN_OWL_ARGS} -o ${DEST}/owl/${SCHEMA_NAME}.owl.ttl $(SOURCE_SCHEMA_PATH)
+endif
+# non-empty arg triggers java
+ifneq ($(strip ${GEN_JAVA_ARGS}),)
+       $(RUN) gen-java ${GEN_JAVA_ARGS} --output-directory ${DEST}/java/ $(SOURCE_SCHEMA_PATH)
+endif
+# non-empty arg triggers typescript
+ifneq ($(strip ${GEN_TS_ARGS}),)
+       $(RUN) gen-typescript ${GEN_TS_ARGS} $(SOURCE_SCHEMA_PATH) >${DEST}/typescript/${SCHEMA_NAME}.ts
+endif
 
 test: test-schema test-python test-examples
 
 test-schema:
-	$(RUN) gen-project ${GEN_PARGS} -d tmp $(SOURCE_SCHEMA_PATH)
+	$(RUN) gen-project ${CONFIG_YAML} -d tmp $(SOURCE_SCHEMA_PATH)
 
 test-python:
 	$(RUN) python -m unittest discover
@@ -158,7 +191,7 @@ $(DOCDIR):
 
 gendoc: $(DOCDIR)
 	cp -rf $(SRC)/docs/* $(DOCDIR) ; \
-	$(RUN) gen-doc ${GEN_DARGS} -d $(DOCDIR) $(SOURCE_SCHEMA_PATH)
+	$(RUN) gen-doc ${GEN_DOC_ARGS} -d $(DOCDIR) $(SOURCE_SCHEMA_PATH)
 
 testdoc: gendoc serve
 

--- a/{{cookiecutter.project_name}}/config.env
+++ b/{{cookiecutter.project_name}}/config.env
@@ -1,8 +1,17 @@
-LINKML_GENERATORS_PROJECT_ARGS=--config-file config.yaml
 
-### Extra layer of configuration for Makefile beyond
-### what 'gen-project --config-file config.yaml' provides.
-### Uncomment and set environment variables as needed.
+###### linkml generator variables, used by makefile
 
-# LINKML_GENERATORS_MARKDOWN_ARGS=--no-mergeimports
+## gen-project configuration file
+LINKML_GENERATORS_CONFIG_YAML= --config-file config.yaml
+
+## pass args if gendoc ignores config.yaml (i.e. --no-mergeimports)
+LINKML_GENERATORS_DOC_ARGS=
+
+## pass args to workaround genowl rdfs config bug (linkml#1453)
+##   (i.e. --no-type-objects --no-metaclasses --metadata-profile rdfs)
+LINKML_GENERATORS_OWL_ARGS=
+
+## pass args to trigger experimental java/typescript generation
+LINKML_GENERATORS_JAVA_ARGS=
+LINKML_GENERATORS_TYPESCRIPT_ARGS=
 


### PR DESCRIPTION
This PR does the following:

- improved variable names and better documentation  in `config.env` and `makefile`

- introduce `LINKML_ENVIRONMENT_FILE`  var for custom configuration location. For example to hide the file via `.config.yaml` or `.config/generators.yaml` or some other odd reason.

- Add some logic to Makefile to use environment variables as action triggers

1. set typescript environment variable (args) to trigger gen-typescript
2. set java environment variable (args) to trigger gen-java
3. set owl environment variable (args) if rdfs is needed (https://github.com/linkml/linkml/issues/1453)

This PR replaces  #69