### PR TITLE
docs(readme): allow overlaying into existing non-linkml project

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,13 @@ The following are required and recommended tools for using this cookiecutter and
 ### Step 1: Generate the project files
 
 To generate a new LinkML project run the following:
-
 ```bash
 cruft create https://github.com/linkml/linkml-project-cookiecutter
+```
+Alternatively, to add linkml project files to pre-existing directory,
+(perhaps an existing non-linkml project), pass `-f` option:
+```bash
+cruft create -f https://github.com/linkml/linkml-project-cookiecutter
 ```
 
 You will be prompted for a few values.  The defaults are fine for most


### PR DESCRIPTION
This PR updates README to communicate that `cruft create` fails if target directory already exists, and that `cruft create -f` is alternative syntax. My use case is pre-existing non-linkml project with same name as linkml `project_name`.