### PR TITLE
mkdocs-filter-and-sort

### DIFF
--- a/{{cookiecutter.project_name}}/mkdocs.yml
+++ b/{{cookiecutter.project_name}}/mkdocs.yml
@@ -16,6 +16,13 @@ nav:
   - About: about.md
 site_url: https://{{cookiecutter.github_org}}.github.io/{{cookiecutter.project_name}}
 repo_url: https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.project_name}}
+markdown_extensions:
+  - tables
+extra_javascript:
+  - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
+  - javascripts/tablesort.js
+  - https://unpkg.com/tablefilter@0.7.3/dist/tablefilter/tablefilter.js
+  - javascripts/tablefilter.js
 
 # Uncomment this block to enable use of Google Analytics.
 # Replace the property value with your own ID.

--- a/{{cookiecutter.project_name}}/src/docs/javascripts/tablefilter.js
+++ b/{{cookiecutter.project_name}}/src/docs/javascripts/tablefilter.js
@@ -1,0 +1,9 @@
+document$.subscribe(function() {
+    var tables = document.querySelectorAll("article table:not([class])")
+    tables.forEach(function(table) {
+      var tf = new TableFilter(table, {
+        base_path: "https://unpkg.com/tablefilter@0.7.3/dist/tablefilter/"
+      })  
+      tf.init()
+    })  
+  })

--- a/{{cookiecutter.project_name}}/src/docs/javascripts/tablesort.js
+++ b/{{cookiecutter.project_name}}/src/docs/javascripts/tablesort.js
@@ -1,0 +1,6 @@
+document$.subscribe(function() {
+    var tables = document.querySelectorAll("article table:not([class])")
+    tables.forEach(function(table) {
+      new Tablesort(table)
+    })
+  })


### PR DESCRIPTION
updated mkdocs.yaml and added .js files such that generated documentation has filter/sort capabilites for tables.

example:
<img width="701" alt="image" src="https://github.com/linkml/linkml-project-cookiecutter/assets/81600274/adc6d39f-e4e9-4ecf-beae-29a1f2089498">
