### PR TITLE
mkdocs sort functionality

### DIFF
--- a/{{cookiecutter.project_name}}/mkdocs.yml
+++ b/{{cookiecutter.project_name}}/mkdocs.yml
@@ -16,6 +16,11 @@ nav:
   - About: about.md
 site_url: https://{{cookiecutter.github_org}}.github.io/{{cookiecutter.project_name}}
 repo_url: https://github.com/{{cookiecutter.github_org}}/{{cookiecutter.project_name}}
+markdown_extensions:
+  - tables
+extra_javascript:
+  - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
+  - javascripts/tablesort.js
 
 # Uncomment this block to enable use of Google Analytics.
 # Replace the property value with your own ID.

--- a/{{cookiecutter.project_name}}/tablesort.js
+++ b/{{cookiecutter.project_name}}/tablesort.js
@@ -1,0 +1,6 @@
+document$.subscribe(function() {
+    var tables = document.querySelectorAll("article table:not([class])")
+    tables.forEach(function(table) {
+      new Tablesort(table)
+    })
+  })


### PR DESCRIPTION
Followup from https://github.com/linkml/linkml-project-cookiecutter/pull/99

Adds sorting functionality to tables in mkdocs documentation.