### PR TITLE
Update to the latest mkdocs-mermaid2-plugin

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -19,7 +19,7 @@ style = "pep440"
 [tool.poetry.dev-dependencies]
 linkml = "^1.3.5"
 mkdocs-material = "^8.2.8"
-mkdocs-mermaid2-plugin = "^0.6.0"
+mkdocs-mermaid2-plugin = "^1.1.1"
 schemasheets = "^0.1.14"
 
 [build-system]


### PR DESCRIPTION
I was hitting an error where the generated docs wouldn't render the mermaid class diagrams. Upgrading to the latest plugin version resolved the issue.