### PR TITLE
GitHub Action workflow to preview documentation changes in PRs

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
 

--- a/{{cookiecutter.project_name}}/.github/workflows/test_pages_build.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test_pages_build.yaml
@@ -1,0 +1,44 @@
+name: Preview cookiecutter.__project_slug}} documentation build
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install dependencies
+        run: poetry install -E docs
+
+      - name: Build documentation
+        run: |
+          mkdir -p site
+          touch site/.nojekyll
+          make gendoc
+          ([ ! -f docs/about.md ] && cp src/docs/about.md docs/) || true
+          poetry run mkdocs build -d site
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: site/
+          preview-branch: gh-pages

--- a/{{cookiecutter.project_name}}/.github/workflows/test_pages_build.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test_pages_build.yaml
@@ -1,4 +1,4 @@
-name: Preview cookiecutter.__project_slug}} documentation build
+name: Preview {{cookiecutter.__project_slug}} documentation build
 
 on:
   pull_request:


### PR DESCRIPTION
This PR seeks to add a GitHub Action workflow that will run everytime there is a new PR and create a link to preview the docs within that PR. It will also run everytime there is a new commit that is piled on top of commits in the open PR.

One of the pros of having this workflow will be that we won't need to create forks of schema repos just for the purpose of being able to create its own documentation site.

To see an example, you can look at the workflow file in action in the NMDC schema repo: https://github.com/microbiomedata/nmdc-schema/pull/2057

Inspiration from https://github.com/linkml/linkml/issues/2029