### PR TITLE
chore: cookiecutter copy-without-rendor support

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -20,3 +20,5 @@ jobs:
         uses: actions/checkout@v3
       - name: Codespell
         uses: codespell-project/actions-codespell@v2
+        with:
+          skip: '*.js'

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,5 +17,9 @@
     "google_sheet_id": "1wVoaiFg47aT9YWNeRfTZ8tYHN8s8PAuDx5i2HUcDpvQ",
     "google_sheet_tabs": "personinfo enums",
     "__google_sheet_module": "{{ cookiecutter.google_sheet_tabs|lower()|replace(' ', '_')|replace('-', '_') }}",
-    "github_token_for_pypi_deployment": "PYPI_PASSWORD"
+    "github_token_for_pypi_deployment": "PYPI_PASSWORD",
+    "_copy_without_render": [
+        "src/docs/js/*",
+        "src/docs/javascript/*"
+    ]
 }


### PR DESCRIPTION
This PR adds "copy without render" placeholder to `cookiecutter.json` per [documentation](https://cookiecutter.readthedocs.io/en/2.6.0/advanced/copy_without_render.html):

_To avoid rendering directories and files of a cookiecutter, the _copy_without_render key can be used in the cookiecutter.json._ 

**Justification**

I was testing  #118 and cookiecutter was failing with huge stracktrace, and after much troubleshooting this PR fixed the issue by skipping the JS file.
``` 
│ ╭──────────────────────────────────── locals ────────────────────────────────────╮ │
│ │ rewrite_traceback_stack = <function rewrite_traceback_stack at 0x7f682b1d8820> │ │
│ │                    self = <cookiecutter.environment.StrictEnvironment object   │ │
│ │                           at 0x7f682b826860>                                   │ │
│ │                  source = '<!DOCTYPE html><html lang="en"><head><script        │ │
│ │                           async="" src="https://www.googletag'+7751699         │ │
│ ╰────────────────────────────────────────────────────────────────────────────────╯ │
│                                                                                    │
│ in template:4                                                                      │
╰────────────────────────────────────────────────────────────────────────────────────╯
TemplateSyntaxError: unexpected char '\\' at 3233749
  File "src/docs/js/test.js", line 4
```