### PR TITLE
Update to Poetry 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A [Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/) template for pr
 
 The following are required and recommended tools for using this cookiecutter and the LinkML project that it generates. This is all one-time setup, so if you have already done it skip to the [next section](#creating-a-new-project)!
 
-  * **Python >= 3.8**
+  * **Python >= 3.9**
   
     LinkML tools are mainly written in Python, so you will need a recent Python interpreter to run this generator and to use the generated project.
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -29,7 +29,7 @@ python = "^3.9"
 linkml-runtime = "^1.1.24"
 
 [tool.poetry.requires-plugins]
-poetry-dynamic-versioning = ">=1.5.0"
+poetry-dynamic-versioning = ">=1.5.2"
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -1,32 +1,45 @@
-[tool.poetry]
+[build-system]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"
+
+[project]
 name = "{{cookiecutter.__project_slug}}"
-version = "0.1.0"
 description = "{{cookiecutter.project_description}}"
-authors = ["{{cookiecutter.__author}}"]
+authors = [
+  {name = "{{cookiecutter.full_name}}", email = "{{cookiecutter.email}}"},
+]
 license = "{{cookiecutter.license}}"
 readme = "README.md"
 include = ["README.md", "src/{{cookiecutter.__project_slug}}/schema", "project"]
 
+requires-python = ">=3.9"
+
+dynamic = ["version"]
+
+dependencies = [
+  "linkml-runtime >=1.8.0",
+]
+
+[tool.poetry]
+requires-poetry = ">=2.0"
+version = "0.0.0"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 linkml-runtime = "^1.1.24"
+
+[tool.poetry.requires-plugins]
+poetry-dynamic-versioning = ">=1.5.0"
 
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
 style = "pep440"
 
-[tool.poetry.dev-dependencies]
-linkml = "^1.3.5"
-mkdocs-material = "^8.2.8"
-mkdocs-mermaid2-plugin = "^1.1.1"
-schemasheets = "^0.1.14"
-jupyter = "^1.0.0"
-mknotebooks = "*"
-
-[build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.backend"
-
-[tool.poetry.extras]
-docs = ["linkml", "mkdocs-material"]
+[tool.poetry.group.dev.dependencies]
+linkml = ">=1.3.5"
+mkdocs-material = ">=8.2.8"
+mkdocs-mermaid2-plugin = ">=1.1.1"
+schemasheets = ">=0.1.14"
+jupyter = ">=1.0.0"
+mknotebooks = ">= 0.8.0"


### PR DESCRIPTION
I have tested Poetry-2.0 in our repo here https://github.com/nfdi4cat/pid4cat-model/pull/36. This PR switches as much as possible to the PEP 621 standard. The few remaining `[tool.poetry....]` sections cannot be converted to PEP 621 but have to stay.

To install the development packages, run `poetry install --with=dev`. Using `poetry install` only installs the minimum which is the model and the linkml-runtime.

Due to PEP 621 conformance switching to Poetry 2.0 is also a good first step to move to [uv](https://docs.astral.sh/uv/) next 😄 