### PR TITLE
Remove redundant specs from pyproject.toml

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-docs.yaml
@@ -29,7 +29,7 @@ jobs:
         run: pipx install poetry
 
       - name: Install dependencies.
-        run: poetry install -E docs
+        run: poetry install
 
       - name: Build documentation.
         run: |

--- a/{{cookiecutter.project_name}}/.github/workflows/test_pages_build.yaml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test_pages_build.yaml
@@ -27,7 +27,7 @@ jobs:
         run: pipx install poetry
 
       - name: Install dependencies
-        run: poetry install -E docs
+        run: poetry install
 
       - name: Build documentation
         run: |

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -12,21 +12,17 @@ license = "{{cookiecutter.license}}"
 readme = "README.md"
 include = ["README.md", "src/{{cookiecutter.__project_slug}}/schema", "project"]
 
-requires-python = ">=3.9"
+requires-python = ">=3.9,<4.0"
 
 dynamic = ["version"]
 
 dependencies = [
-  "linkml-runtime >=1.8.0",
+  "linkml-runtime >=1.1.24",
 ]
 
 [tool.poetry]
 requires-poetry = ">=2.0"
 version = "0.0.0"
-
-[tool.poetry.dependencies]
-python = "^3.9"
-linkml-runtime = "^1.1.24"
 
 [tool.poetry.requires-plugins]
 poetry-dynamic-versioning = ">=1.5.2"


### PR DESCRIPTION
After the upgrade to poetry 2, the Python and linkml-runtime dependencies are declared at two places in `pyproject.toml`. This removes the redundancy. 

It was just an oversight in #128. `poetry check` does not complain and the project setup and installation works fine even with the redundant spec as long as there is no contradiction.

This also fixes the installation in the docs-related gh-actions (#133): 
- mkdocs-related packages are installed as dev-dependencies and not as extras.

Closes #133