### PR TITLE
Copy example folder recursively in make & just commands

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -120,7 +120,7 @@ compile-sheets:
 
 # In future this will be done by conversion
 gen-examples:
-	cp src/data/examples/* $(EXAMPLEDIR)
+	cp -r src/data/examples/* $(EXAMPLEDIR)
 
 # generates all project files
 {% if cookiecutter.use_schemasheets == "Yes"  %}

--- a/{{cookiecutter.project_name}}/justfile
+++ b/{{cookiecutter.project_name}}/justfile
@@ -102,7 +102,7 @@ _compile_sheets:
 # Generate examples
 _gen-examples:
     mkdir -p {{exampledir}}
-    cp src/data/examples/* {{exampledir}}
+    cp -r src/data/examples/* {{exampledir}}
 
 # Generate project files
 _gen-project: _ensure_pymodel_dir _compile_sheets


### PR DESCRIPTION
As a result of correcting the example-folder structure in #136, copying of the folder has to be done recursively now.